### PR TITLE
Change observatory.morrolan.ch URLs to use HTTPS.

### DIFF
--- a/lua/NS2Plus/Client/CHUDGUI_EndStats.lua
+++ b/lua/NS2Plus/Client/CHUDGUI_EndStats.lua
@@ -15,7 +15,7 @@ local screenHeight = Client.GetScreenHeight()
 local aspectRatio = screenWidth/screenHeight
 
 local kSteamProfileURL = "http://steamcommunity.com/profiles/"
-local kObservatoryUserURL = "http://observatory.morrolan.ch/player?steam_id="
+local kObservatoryUserURL = "https://observatory.morrolan.ch/player?steam_id="
 
 -- To avoid printing 200.00 or things like that
 local function printNum(number)

--- a/lua/NS2Plus/GUIScripts/GUIScoreboard.lua
+++ b/lua/NS2Plus/GUIScripts/GUIScoreboard.lua
@@ -1,7 +1,7 @@
 local kNSLUserURL = "http://www.ensl.org/users/"
 local kNSLTeamURL = "http://www.ensl.org/teams/"
 
-local kObservatoryUserURL = "http://observatory.morrolan.ch/player?steam_id="
+local kObservatoryUserURL = "https://observatory.morrolan.ch/player?steam_id="
 
 local team1Skill, team2Skill, team1VictoryP = 0, 0, 0
 local textHeight, teamItemWidth


### PR DESCRIPTION
Prevents the client having to follow an unnecessary redirect.