### PR TITLE
Reload Indicator - minor optimization

### DIFF
--- a/lua/NS2Plus/GUIScripts/GUICrosshair.lua
+++ b/lua/NS2Plus/GUIScripts/GUICrosshair.lua
@@ -42,20 +42,27 @@ local originalCrossUpdate = GUICrosshair.Update
 function GUICrosshair:Update(deltaTime)
 	originalCrossUpdate(self)
 
-	local reloadFraction = CHUDGetReloadFraction()
-	local reloadIndicator = CHUDGetOption("reloadindicator")
-	local reloadIndicatorVisible = reloadIndicator == 1 and gCHUDHiddenViewModel or reloadIndicator == 2
-	-- For some reason having this initialized isn't enough so let's check for it every frame
-	if self.reloadDial and self.crosshairs:GetIsVisible() and reloadIndicatorVisible and reloadFraction > -1 then
-		self.updateInterval = kUpdateIntervalFull
-		self.reloadDial:SetIsVisible(true)
-		self.reloadDial:SetPercentage(reloadFraction)
-		self.reloadDial:Update(deltaTime)
+    local reloadIndicator = CHUDGetOption("reloadindicator")
+	if reloadIndicator > 0 then
+		local reloadFraction = CHUDGetReloadFraction()	
+		local reloadIndicatorVisible = reloadIndicator == 1 and gCHUDHiddenViewModel or reloadIndicator == 2
+		-- For some reason having this initialized isn't enough so let's check for it every frame
+		if self.reloadDial and self.crosshairs:GetIsVisible() and reloadIndicatorVisible and reloadFraction > -1 then
+			self.updateInterval = kUpdateIntervalFull
+			self.reloadDial:SetIsVisible(true)
+			self.reloadDial:SetPercentage(reloadFraction)
+			self.reloadDial:Update(deltaTime)
+		else	
+			self.updateInterval = 0.04 
+			if self.reloadDial then
+				self.reloadDial:SetIsVisible(false)
+			end
+		end
 	else
-		self.updateInterval = 0.04
+		self.updateInterval = 0.1 -- = 1000ms
 		if self.reloadDial then
 			self.reloadDial:SetIsVisible(false)
-		end
+		end	
 	end
 end
 	

--- a/lua/NS2Plus/GUIScripts/GUICrosshair.lua
+++ b/lua/NS2Plus/GUIScripts/GUICrosshair.lua
@@ -48,7 +48,7 @@ function GUICrosshair:Update(deltaTime)
 		local reloadIndicatorVisible = reloadIndicator == 1 and gCHUDHiddenViewModel or reloadIndicator == 2
 		-- For some reason having this initialized isn't enough so let's check for it every frame
 		if self.reloadDial and self.crosshairs:GetIsVisible() and reloadIndicatorVisible and reloadFraction > -1 then
-			self.updateInterval = kUpdateIntervalFull
+			self.updateInterval = 0.004
 			self.reloadDial:SetIsVisible(true)
 			self.reloadDial:SetPercentage(reloadFraction)
 			self.reloadDial:Update(deltaTime)


### PR DESCRIPTION
slightly reduces weightload if the setting is turned off

If turned on the updateinterval slightly increased
(Testing: Join Marine and change the 3 Settings of the reload indicator + if viewmodel is on/off)